### PR TITLE
Feature/detail banner slider

### DIFF
--- a/src/components/DetailBannerSlider/DetailBannerSlider.js
+++ b/src/components/DetailBannerSlider/DetailBannerSlider.js
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import css from './DetailBannerSlider.module.scss';
+import { MdArrowBackIos, MdArrowForwardIos } from 'react-icons/md';
+
+function DetailBannerSlider() {
+  const [data, setData] = useState({});
+
+  useEffect(() => {
+    fetch('http://localhost:3000/data/DetailBannerSlider.json')
+      .then(res => res.json())
+      .then(fetchdata => {
+        setData(fetchdata);
+      });
+  }, []);
+
+  return (
+    <div className={css.component}>
+      <div className={css.carousel}>
+        <div className={css.cardContainer}>
+          {data.images &&
+            data.images.map((a, i) => {
+              return (
+                <div className={css.card} key={i}>
+                  <div
+                    className={css.promtionImg}
+                    style={{
+                      backgroundImage: `url(${data.images[i]})`,
+                    }}
+                  />
+                </div>
+              );
+            })}
+        </div>
+        <div className={css.sliderBtn}>
+          <div>
+            <MdArrowBackIos size={20} />
+          </div>
+          <div>
+            <MdArrowForwardIos size={20} />
+          </div>
+        </div>
+        <div className={css.roomInfo}>
+          <div className={css.roomDetail1}>
+            <span className={css.roomConcept}>{data.concept}</span>
+            <div className={css.link}>
+              <span>MAGAZINE</span>
+              <span>PICK</span>
+              <span>PROMOTION</span>
+            </div>
+          </div>
+          <div className={css.roomDetail2}>
+            <span className={css.roomName}>{data.room_name}</span>
+            <div className={css.location}>
+              <span>{data.province}</span>
+              <span>{data.city}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DetailBannerSlider;

--- a/src/components/DetailBannerSlider/DetailBannerSlider.js
+++ b/src/components/DetailBannerSlider/DetailBannerSlider.js
@@ -1,9 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import css from './DetailBannerSlider.module.scss';
 import { MdArrowBackIos, MdArrowForwardIos } from 'react-icons/md';
 
 function DetailBannerSlider() {
   const [data, setData] = useState({});
+  const dataLength = data.images?.length;
+  let dataImages = [];
+  let cardContainerRef = useRef();
+  const carouselRef = useRef();
 
   useEffect(() => {
     fetch('http://localhost:3000/data/DetailBannerSlider.json')
@@ -13,18 +17,89 @@ function DetailBannerSlider() {
       });
   }, []);
 
+  if (data.images !== undefined) {
+    dataImages = [data.images[dataLength - 1], ...data.images, data.images[0]];
+  }
+
+  useEffect(() => {
+    cardContainerRef.current.style.scrollBehavior = 'auto';
+    cardContainerRef.current.scrollLeft = carouselRef.current.offsetWidth;
+  }, [cardContainerRef.current]);
+
+  const sliderLeft = () => {
+    infinity();
+    cardContainerRef.current.style.scrollBehavior = 'smooth';
+    cardContainerRef.current.scrollLeft -= carouselRef.current.offsetWidth;
+  };
+
+  const sliderRight = () => {
+    infinity();
+    cardContainerRef.current.style.scrollBehavior = 'smooth';
+    cardContainerRef.current.scrollLeft += carouselRef.current.offsetWidth;
+  };
+
+  const infinity = () => {
+    if (cardContainerRef.current.scrollLeft === 0) {
+      cardContainerRef.current.style.scrollBehavior = 'auto';
+      cardContainerRef.current.scrollLeft =
+        carouselRef.current.offsetWidth * dataLength;
+    }
+
+    if (
+      cardContainerRef.current.scrollLeft ===
+      carouselRef.current.offsetWidth * (dataLength + 1)
+    ) {
+      cardContainerRef.current.style.scrollBehavior = 'auto';
+      cardContainerRef.current.scrollLeft = carouselRef.current.offsetWidth;
+    }
+  };
+
+  let isPressedDown = false;
+  let cursorXspace;
+
+  useEffect(() => {
+    window.addEventListener('mouseup', () => {
+      isPressedDown = false;
+    });
+
+    carouselRef.current.addEventListener('mousedown', e => {
+      isPressedDown = true;
+      cursorXspace = e.offsetX - cardContainerRef.current.offsetLeft;
+    });
+
+    carouselRef.current.addEventListener('mouseup', () => {
+      isPressedDown = false;
+    });
+
+    carouselRef.current.addEventListener('mousemove', e => {
+      infinity();
+
+      if (!isPressedDown) return;
+      e.preventDefault();
+      cardContainerRef.current.style.scrollBehavior = 'smooth';
+      if (cursorXspace - e.offsetX > carouselRef.current.offsetWidth * 0.2) {
+        cardContainerRef.current.scrollLeft += carouselRef.current.offsetWidth;
+      } else if (
+        cursorXspace - e.offsetX <
+        carouselRef.current.offsetWidth * -0.2
+      ) {
+        cardContainerRef.current.scrollLeft -= carouselRef.current.offsetWidth;
+      }
+    });
+  }, [carouselRef.current]);
+
   return (
     <div className={css.component}>
-      <div className={css.carousel}>
-        <div className={css.cardContainer}>
-          {data.images &&
-            data.images.map((a, i) => {
+      <div className={css.carousel} ref={carouselRef}>
+        <div className={css.cardContainer} ref={cardContainerRef}>
+          {dataImages &&
+            dataImages.map((a, i) => {
               return (
                 <div className={css.card} key={i}>
                   <div
                     className={css.promtionImg}
                     style={{
-                      backgroundImage: `url(${data.images[i]})`,
+                      backgroundImage: `url(${dataImages[i]})`,
                     }}
                   />
                 </div>
@@ -32,10 +107,10 @@ function DetailBannerSlider() {
             })}
         </div>
         <div className={css.sliderBtn}>
-          <div>
+          <div onClick={sliderLeft}>
             <MdArrowBackIos size={20} />
           </div>
-          <div>
+          <div onClick={sliderRight}>
             <MdArrowForwardIos size={20} />
           </div>
         </div>

--- a/src/components/DetailBannerSlider/DetailBannerSlider.js
+++ b/src/components/DetailBannerSlider/DetailBannerSlider.js
@@ -2,6 +2,22 @@ import React, { useEffect, useRef, useState } from 'react';
 import css from './DetailBannerSlider.module.scss';
 import { MdArrowBackIos, MdArrowForwardIos } from 'react-icons/md';
 
+const infinity = (cardContainerRef, carouselRef, dataLength) => {
+  if (cardContainerRef.current.scrollLeft === 0) {
+    cardContainerRef.current.style.scrollBehavior = 'auto';
+    cardContainerRef.current.scrollLeft =
+      carouselRef.current.offsetWidth * dataLength;
+  }
+
+  if (
+    cardContainerRef.current.scrollLeft ===
+    carouselRef.current.offsetWidth * (dataLength + 1)
+  ) {
+    cardContainerRef.current.style.scrollBehavior = 'auto';
+    cardContainerRef.current.scrollLeft = carouselRef.current.offsetWidth;
+  }
+};
+
 function DetailBannerSlider() {
   const [data, setData] = useState({});
   const dataLength = data.images?.length;
@@ -24,68 +40,64 @@ function DetailBannerSlider() {
   useEffect(() => {
     cardContainerRef.current.style.scrollBehavior = 'auto';
     cardContainerRef.current.scrollLeft = carouselRef.current.offsetWidth;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cardContainerRef.current]);
 
   const sliderLeft = () => {
-    infinity();
+    infinity(cardContainerRef, carouselRef, dataLength);
     cardContainerRef.current.style.scrollBehavior = 'smooth';
     cardContainerRef.current.scrollLeft -= carouselRef.current.offsetWidth;
   };
 
   const sliderRight = () => {
-    infinity();
+    infinity(cardContainerRef, carouselRef, dataLength);
     cardContainerRef.current.style.scrollBehavior = 'smooth';
     cardContainerRef.current.scrollLeft += carouselRef.current.offsetWidth;
   };
 
-  const infinity = () => {
-    if (cardContainerRef.current.scrollLeft === 0) {
-      cardContainerRef.current.style.scrollBehavior = 'auto';
-      cardContainerRef.current.scrollLeft =
-        carouselRef.current.offsetWidth * dataLength;
-    }
-
-    if (
-      cardContainerRef.current.scrollLeft ===
-      carouselRef.current.offsetWidth * (dataLength + 1)
-    ) {
-      cardContainerRef.current.style.scrollBehavior = 'auto';
-      cardContainerRef.current.scrollLeft = carouselRef.current.offsetWidth;
-    }
-  };
-
-  let isPressedDown = false;
-  let cursorXspace;
-
   useEffect(() => {
-    window.addEventListener('mouseup', () => {
-      isPressedDown = false;
-    });
+    let isPressedDown = false;
+    let cursorXspace;
 
-    carouselRef.current.addEventListener('mousedown', e => {
+    const carouselRefCurrent = carouselRef.current;
+
+    function mouseUpCallback() {
+      isPressedDown = false;
+    }
+
+    function mouseDownCallback(e) {
       isPressedDown = true;
       cursorXspace = e.offsetX - cardContainerRef.current.offsetLeft;
-    });
+    }
 
-    carouselRef.current.addEventListener('mouseup', () => {
-      isPressedDown = false;
-    });
-
-    carouselRef.current.addEventListener('mousemove', e => {
-      infinity();
+    function mouseMoveCallback(e) {
+      infinity(cardContainerRef, carouselRef, dataLength);
 
       if (!isPressedDown) return;
       e.preventDefault();
       cardContainerRef.current.style.scrollBehavior = 'smooth';
-      if (cursorXspace - e.offsetX > carouselRef.current.offsetWidth * 0.2) {
-        cardContainerRef.current.scrollLeft += carouselRef.current.offsetWidth;
+      if (cursorXspace - e.offsetX > carouselRefCurrent.offsetWidth * 0.2) {
+        cardContainerRef.current.scrollLeft += carouselRefCurrent.offsetWidth;
       } else if (
         cursorXspace - e.offsetX <
-        carouselRef.current.offsetWidth * -0.2
+        carouselRefCurrent.offsetWidth * -0.2
       ) {
-        cardContainerRef.current.scrollLeft -= carouselRef.current.offsetWidth;
+        cardContainerRef.current.scrollLeft -= carouselRefCurrent.offsetWidth;
       }
-    });
+    }
+
+    window.addEventListener('mouseup', mouseUpCallback);
+    carouselRefCurrent.addEventListener('mousedown', mouseDownCallback);
+    carouselRefCurrent.addEventListener('mouseup', mouseUpCallback);
+    carouselRefCurrent.addEventListener('mousemove', mouseMoveCallback);
+
+    return () => {
+      window.removeEventListener('mouseup', mouseUpCallback);
+      carouselRefCurrent.removeEventListener('mousedown', mouseDownCallback);
+      carouselRefCurrent.removeEventListener('mouseup', mouseUpCallback);
+      carouselRefCurrent.removeEventListener('mousemove', mouseMoveCallback);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [carouselRef.current]);
 
   return (

--- a/src/components/DetailBannerSlider/DetailBannerSlider.module.scss
+++ b/src/components/DetailBannerSlider/DetailBannerSlider.module.scss
@@ -1,0 +1,131 @@
+.component {
+  height: 650px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.carousel {
+  width: 100%;
+  max-width: 1800px;
+  height: 650px;
+  position: relative;
+}
+
+.cardContainer {
+  display: flex;
+  flex-wrap: nowrap;
+  overflow: hidden;
+  overflow-x: scroll;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+  scroll-snap-type: x mandatory;
+}
+
+.cardContainer::-webkit-scrollbar {
+  display: none;
+}
+
+.card {
+  width: 100%;
+  height: 650px;
+  flex-shrink: 0;
+  scroll-snap-align: center;
+}
+
+.promtionImg {
+  width: 100%;
+  height: 100%;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center center;
+  cursor: pointer;
+}
+
+.sliderBtn {
+  width: 100%;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  justify-content: space-between;
+
+  div {
+    width: 60px;
+    height: 60px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: #232222c2;
+    color: #a9a5a5;
+  }
+}
+
+.roomInfo {
+  width: 100%;
+  max-width: 1280px;
+  height: 80px;
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #000000d9;
+  color: #ffffff;
+}
+
+.roomDetail1 {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 30px;
+
+  .roomConcept {
+    min-width: 500px;
+    font-size: 26px;
+    font-weight: 400;
+  }
+
+  .link {
+    max-width: 300px;
+    width: 30%;
+    display: flex;
+    justify-content: space-between;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 26px;
+    color: #ffffff87;
+  }
+}
+
+.roomDetail2 {
+  width: 100%;
+  max-width: 295px;
+  min-width: 150px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-left: 1px solid #ffffff87;
+
+  .roomName {
+    font-weight: 500;
+    font-size: 18px;
+  }
+
+  .location {
+    margin-top: 8px;
+    font-size: 12px;
+    font-weight: 100;
+    letter-spacing: 1.5px;
+    color: #ffffff87;
+
+    span:nth-child(2)::before {
+      content: '/';
+      margin: 0 5px;
+    }
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [X] 레이아웃 구현
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 

- Detail 페이지 banner slider 레이아웃 및 기능 구현

<br />

## :: 구현 사항 설명 

1. 버튼 클릭, 마우스 가로휠, 드래그를 통한 슬라이더 조작

- 버튼, 마우스 가로휠 사용 : 슬라이더 카드의 가로 길이만큼 가로 스크롤이 이동
- 드래그 : 슬라이더 위에서 현재 카드 길이*0.2 이상의 드래그가 발생할 경우, 슬라이더 카드의 가로 길이만큼 가로 스크롤이 이동

2. 슬라이더 무한 루프

- [마지막 카드①, 첫번째 카드① ... 마지막 카드②, 첫번째 카드②] 순으로 슬라이더의 이미지를 가로 배치
- 마지막 카드①에서 왼쪽으로 이동 시 마지막 카드②로 이동 후 동작하는 형태로 구현(동일하게, 첫번째 카드②에서 오른쪽으로 이동 시 첫번째 카드①로 이동 후 동작)

<br />

## :: 성장 포인트 

- 브라우저 페이지를 기준으로 엘리먼트의 위치, 크기, 스크롤의 위치 등 값을 구하고 조작하는 방법을 알게 되었다.
- 슬라이더를 버튼과 마우스휠, 드래그로 동작하게 만들면서, 동일한 요소를 여러가지 방법으로 조작하는 효율적인 로직에 대해 고민하게 되었다.
- max-width와 min-width css속성을 사용하여 반응형 페이지를 구현하고자 하였다.

<br />

## :: 기타 질문 및 특이 사항
